### PR TITLE
bug fix

### DIFF
--- a/mqtt-connect.py
+++ b/mqtt-connect.py
@@ -95,12 +95,12 @@ key_emoji = "\U0001F511"
 encrypted_emoji = "\U0001F512"
 dm_emoji = "\u2192"
 
-client_short_name = "WXE1"
-client_long_name = "WX-Engine"
-lat = "3.007494"
-lon = "101.580010"
-alt = "25"
-client_hw_model = 70
+client_short_name = "MCM"
+client_long_name = "MQTTastic"
+lat = ""
+lon = ""
+alt = ""
+client_hw_model = 255
 node_info_interval_minutes = 15
 
 #################################

--- a/mqtt-connect.py
+++ b/mqtt-connect.py
@@ -1494,9 +1494,9 @@ if sys.platform.startswith('darwin'):
     print("The built in window auto-centering code may help with this\n\n")
 
 # Generate 4 random hexadecimal characters to create a unique node name
-#random_hex_chars = ''.join(random.choices('0123456789abcdef', k=4))
-#node_name = '!abcd' + random_hex_chars
-node_name = '!b03d8888'
+random_hex_chars = ''.join(random.choices('0123456789abcdef', k=4))
+node_name = '!abcd' + random_hex_chars
+
 if not is_valid_hex(node_name, 8, 8):
     print('Invalid generated node name: ' + str(node_name))
     sys.exit(1)

--- a/mqtt-connect.py
+++ b/mqtt-connect.py
@@ -83,11 +83,11 @@ record_locations: bool = True
 
 #################################
 ### Default settings
-mqtt_broker = "mqtt.lucifernet.com"
+mqtt_broker = "mqtt.meshtastic.org"
 mqtt_port = 1883
 mqtt_username = "meshdev"
 mqtt_password = "large4cats"
-root_topic = "msh/MY_919/2/e/"
+root_topic = "msh/US/2/e/"
 channel = "LongFast"
 key = "AQ=="
 max_msg_len = mesh_pb2.Constants.DATA_PAYLOAD_LEN


### PR DESCRIPTION
- Python 3.12 deprecated the default datetime adapters and converters in sqlite3 due to bugs and inconsistencies 
- The change is simple: replace datetime.strptime(existing_record[2], "%Y-%m-%d %H:%M:%S") with datetime.fromisoformat(existing_record[2]) since the new adapter stores datetime values in ISO format.
- Instead of destination_id = int(destination_id[1:], 16) , I added logic to properly extract the hex ID from the complex string format
- Split by space : destination_id.split()[0] gets the first part before any spaces
- Handle optional '!' prefix : Check if the hex ID starts with '!' and remove it if present
- Convert to int : Parse the cleaned hex string as a hexadecimal number